### PR TITLE
[설정] pnpm 설치를 위한 peerDependencies 추가

### DIFF
--- a/.changeset/goofy-corners-chew.md
+++ b/.changeset/goofy-corners-chew.md
@@ -1,0 +1,7 @@
+---
+"@huray/eslint-config-react": patch
+"@huray/eslint-config-core": patch
+"@huray/eslint-config-next": patch
+---
+
+peerDependencies 패키지 추가

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ export default defineConfig([
 
 ```bash
 npx @huray/eslint-config-core
-# 또는
-yarn dlx @huray/eslint-config-core
-# 또는
-pnpm dlx @huray/eslint-config-core
 ```
 
 실행하면 `.vscode/settings.json`, `.vscode/extensions.json`을 기준으로 설정을 적용합니다.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,13 +19,8 @@
     "huray",
     "rules"
   ],
-  "author": "Huray <dev@huray.net>",
+  "author": "Huray",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/huraypositive/eslint-config.git",
-    "directory": "packages/core"
-  },
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/next/index.js
+++ b/packages/next/index.js
@@ -19,6 +19,7 @@ const eslintPluginReact = require('eslint-plugin-react');
 
 const nextVitals = require('eslint-config-next/core-web-vitals');
 const nextTs = require('eslint-config-next/typescript');
+const tailwindPrettierPlugin = require.resolve('prettier-plugin-tailwindcss');
 
 const {
   baseRules,
@@ -73,7 +74,7 @@ module.exports = [
         'warn',
         {
           ...prettierOptions,
-          plugins: ['prettier-plugin-tailwindcss'],
+          plugins: [tailwindPrettierPlugin],
           tailwindFunctions: ['clsx', 'cva', 'cn'],
         },
         { usePrettierrc: false },

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -18,13 +18,8 @@
     "tailwindcss",
     "prettier"
   ],
-  "author": "Huray <dev@huray.net>",
+  "author": "Huray",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/huraypositive/eslint-config.git",
-    "directory": "packages/next"
-  },
   "engines": {
     "node": ">=18.0.0"
   },
@@ -33,14 +28,16 @@
   },
   "dependencies": {
     "@huray/eslint-config-core": "workspace:*",
-    "eslint": "^9.0.0",
     "eslint-config-next": "^16.0.7",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.37.0",
-    "prettier": "^3.0.0",
     "prettier-plugin-tailwindcss": "^0.6.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0",
+    "prettier": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,13 +17,8 @@
     "react-hooks",
     "jsx"
   ],
-  "author": "Huray <dev@huray.net>",
+  "author": "Huray",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/huraypositive/eslint-config.git",
-    "directory": "packages/react"
-  },
   "engines": {
     "node": ">=18.0.0"
   },
@@ -31,12 +26,14 @@
     "@huray/eslint-config-core": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
-    "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "eslint-plugin-jsx-a11y": "^6.10.0",
+    "eslint-plugin-jsx-a11y": "^6.10.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0",
     "prettier": "^3.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
## 🔎 PR 내용
- **JIRA** : 카드번호 (링크)

## 🛠 작업사항

### [ 패키지 매니저별 의존성 해석 방식 차이]
- Yarn(v1)은 의존성을 상위로 많이 hoist하기 때문에, 소비 프로젝트가 직접 설치하지 않은 의존성(eslint, prettier, 일부 플러그인)도 우연히 해석되는 경우가 있음
- pnpm은 의존성 격리/엄격 해석을 기본으로 하므로, 소비 프로젝트에 명시되지 않은 패키지는 런타임/에디터(ESLint extension)에서 해석 실패가 발생할 수 있음

### [ 대응 방향 ]
- 프로젝트가 반드시 가져야 하는 실행 도구(eslint, prettier)는 peerDependencies로 명시

### 📸 ScreenShot
