### PR TITLE
[설정] pnpm에서 npx 실행을 위한 bin 항목 추가

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
     ".": "./index.js"
   },
   "bin": {
-    "huray-eslint-config-init": "./init-vscode.js"
+    "huray-eslint-config-init": "./init-vscode.js",
+    "eslint-config-core": "./init-vscode.js"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
## Summary

- `@huray/eslint-config-core` 패키지의 `bin` 필드에 `eslint-config-core` 항목 추가
- pnpm은 `npx <패키지명>` 실행 시 bin 이름이 패키지명(스코프 제외)과 일치해야 동작함
- 기존 `huray-eslint-config-init` bin은 yarn/npm의 fallback으로만 동작했으며, pnpm에서는 실행 불가

## Test plan

- [ ] yarn 환경: `npx @huray/eslint-config-core` 정상 동작 확인
- [ ] pnpm 환경: `npx @huray/eslint-config-core` 정상 동작 확인