### PR TITLE
[설정] release 워크플로우 레포 이름 수정

### DIFF
--- a/.changeset/tame-zoos-sip.md
+++ b/.changeset/tame-zoos-sip.md
@@ -1,0 +1,5 @@
+---
+"@huray/eslint-config-core": patch
+---
+
+pnpm 기준 npx 실행 명령어 수정

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    if: github.repository == 'huraypositive/eslint-config'
+    if: github.repository == 'huraypositive/frontend-eslint-config'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- `release.yml`의 `if` 조건에 하드코딩된 레포 이름이 `huraypositive/eslint-config`로 되어 있어 워크플로우가 항상 skip되는 문제 수정
- 실제 레포 이름인 `huraypositive/frontend-eslint-config`로 변경

## Test plan

- [ ] master 병합 후 GitHub Actions Release 워크플로우가 skip 없이 실행되는지 확인
- [ ] Version Packages PR이 자동 생성되는지 확인